### PR TITLE
adding direct link for youtube brand confirmation

### DIFF
--- a/index.md
+++ b/index.md
@@ -109,6 +109,8 @@ layout: page
   </div>
 </div>
 
+<a href="https://plus.google.com/111950636722130374880" rel="publisher"></a>
+
 [meetup]: http://www.meetup.com/sandiegojs/ "Meetup.com page"
 [github]: https://github.com/sandiegojs/sandiegojs.github.com "Sandiego.js Github site"
 [issues]: https://github.com/sandiegojs/sandiegojs.github.com/issues "Sandiego.js issue tracker"


### PR DESCRIPTION
I would like to get a named channel on youtube. This can be accomplished by "direct linking" a website. see; https://support.google.com/business/answer/4569085?rd=1