### PR TITLE
Fix validation errors and add description meta tags to main pages.

### DIFF
--- a/_posts/2013/2013-06-04-june-meetup.md
+++ b/_posts/2013/2013-06-04-june-meetup.md
@@ -3,7 +3,7 @@ layout: post
 category : meetups
 tags : [presentation, meetup, editorconfig, cordova, phonegap]
 title : Meetup - Phonegap & EditorConfig
-speaker : Scott Mathson & Trey Hunner
+speaker : Scott Mathson &amp; Trey Hunner
 meetupDate : 2013-06-04
 topic : Phonegap & EditorConfig
 details : Hybrid Development with Phonegap & EditorConfig for Tool Management

--- a/_posts/2013/2013-08-06-august-meetup.md
+++ b/_posts/2013/2013-08-06-august-meetup.md
@@ -3,7 +3,7 @@ layout: post
 category : meetups
 tags : [presentation, meetup, gnu, readline, cli, navigation timing api]
 title : Meetup - Browser Based CLI & Navigation Timing API
-speaker : Arne Claassen & James Andrew Vaughn
+speaker : Arne Claassen &amp; James Andrew Vaughn
 meetupDate : 2013-08-06
 topic : Josh.js & Navigation Timing API
 details : CLI support for the browser and debugging end-to-end latencies

--- a/_posts/2014/2014-06-03-meetup.md
+++ b/_posts/2014/2014-06-03-meetup.md
@@ -2,7 +2,7 @@
 layout: post
 category : meetups
 tags : [presentation, meetup, ember, gif, microlib, meme]
-title : Meetup - Deal With It & Fake It Til' You Make It
+title : Meetup - Deal With It &amp; Fake It Til' You Make It
 speaker : Xavier Lange and Heather Brysiewicz
 meetupDate : 2014-06-03
 topic :

--- a/about.md
+++ b/about.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: About sandiego.js
+description: San Diego JS history, leadership and contact information.
 ---
 {% include JB/setup %}
 

--- a/archive.html
+++ b/archive.html
@@ -3,6 +3,7 @@ layout: page
 title : Archive
 header : Post Archive
 group: navigation
+description: Archive of San Diego JS blog posts.
 ---
 {% include JB/setup %}
 

--- a/assets/themes/twitter/css/style.css
+++ b/assets/themes/twitter/css/style.css
@@ -175,6 +175,12 @@ footer {
   border: 4px solid hsl(200, 100%, 40%);
 }
 
+.page-divider {
+  height: 1px;
+  margin: 50px 0;
+  background-color: #EEEEEE;
+}
+
 /* tag_box ======================================================== */
 
 .tag_box {

--- a/chat-room.md
+++ b/chat-room.md
@@ -2,6 +2,7 @@
 layout: page
 title: Chat Room
 group: navigation
+description: Information on online chat rooms for San Diego JS members. 
 ---
 {% include JB/setup %}
 

--- a/code-of-conduct.md
+++ b/code-of-conduct.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Code of Conduct
+description: San Diego JS standards of behavior to ensure a welcoming and inclusive experience for everyone. 
 ---
 {% include JB/setup %}
 

--- a/github.md
+++ b/github.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Using Github to contribute to sandiego.js
+description: Instruction on how members can contribute to the website using github.
 ---
 {% include JB/setup %}
 

--- a/give-a-talk.md
+++ b/give-a-talk.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: We want you to give a talk!
+description: Information and support to encourage members to present at user group meetings. 
 ---
 {% include JB/setup %}
 

--- a/hacknight.md
+++ b/hacknight.md
@@ -1,6 +1,7 @@
 ---
 layout: page
 title: Hack Night Details
+description: Monthly hands-on meeting where members collaborate, interact and relax. 
 ---
 
 {% include JB/setup %}

--- a/index.md
+++ b/index.md
@@ -1,5 +1,7 @@
 ---
 layout: page
+title: San Diego JavaScript Users Group
+description: San Diego's JavaScript users group featuring events, meet-ups, education, support and job postings.
 ---
 {% include JB/setup %}
 
@@ -45,7 +47,7 @@ layout: page
   </div>
 </div>
 
-<hr>
+<div><hr></div>
 
 <div class="row">
   <div class="span8">
@@ -83,7 +85,7 @@ layout: page
   </div>
 </div>
 
-<hr>
+<div><hr></div>
 
 ### Sponsored and supported by
 

--- a/index.md
+++ b/index.md
@@ -47,7 +47,7 @@ description: San Diego's JavaScript users group featuring events, meet-ups, educ
   </div>
 </div>
 
-<div><hr></div>
+<div class="page-divider"></div>
 
 <div class="row">
   <div class="span8">
@@ -85,7 +85,7 @@ description: San Diego's JavaScript users group featuring events, meet-ups, educ
   </div>
 </div>
 
-<div><hr></div>
+<div class="page-divider"></div>
 
 ### Sponsored and supported by
 

--- a/jobs.md
+++ b/jobs.md
@@ -2,6 +2,7 @@
 layout: page
 title: The Jobs Page
 tagline: Where Opportunity and Talent Intersect
+description: JavaScript job opportunities and resumes posted by our members.
 ---
 {% include JB/setup %}
 


### PR DESCRIPTION
I wanted to re-learn how to use github and so went looking for 'any excuse at all' to tinker with the website so I could submit a pull request. I decided to try and add description meta tags to the main pages (which turned out to be just a matter of adding a description attribute to the the YAML front matter). 

Noticed that the title tag on the homepage was empty. Added it back to the YAML front matter and noticed that it not only filled in the title meta tag, but also the h1 tag on the page. So this adds the title to the main page that isn't currently there. Not sure if that is desired or not, so check it out.

Ran the homepage and RSS feed through the W3C validator and found that the hr tags on the homepage were being wrapped in p tags by Jekyll. One solution to the problem is to wrap it in a div tag.

Also found unescaped ampersands in the titles of three posts were causing the RSS feed to error, so  I went back and fixed those.

Here is a list of descriptions all in one place to make it easy to discuss/edit (I may not be the world's best description tag author):

* Homepage: San Diego's JavaScript users group featuring events, meet-ups, education, support and job postings.
* About Us: San Diego JS history, leadership and contact information.
* Give a Talk: Information and support to encourage members to present at user group meetings.
* How to Contribute: Instruction on how members can contribute to the website using github.
* Jobs: JavaScript job opportunities and resumes posted by our members.
* Code of Conduct: San Diego JS standards of behavior to ensure a welcoming and inclusive experience for everyone.
* Archive: Archive of San Diego JS blog posts.
* Chat Room: Information on online chat rooms for San Diego JS members.